### PR TITLE
feat: and client methods for spot fill API

### DIFF
--- a/apiclient/spot_client.go
+++ b/apiclient/spot_client.go
@@ -87,7 +87,7 @@ func (client *ApiClient) CancelSpotOrder(orderId models.OrderID) (*models.Generi
 }
 
 func (client *ApiClient) CancelSpotOrderByClientID(clientOrderId models.OrderID) (*models.GenericResponse[any], error) {
-	path := models.V1SpotOrdersPath + "/client:" + string(clientOrderId)
+	path := models.V1SpotOrdersPath + "/" + models.V1SpotClientOrderIDPrefix + string(clientOrderId)
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
@@ -100,4 +100,52 @@ func (client *ApiClient) CancelSpotOrderByClientID(clientOrderId models.OrderID)
 	}
 
 	return res, nil
+}
+
+func (client *ApiClient) GetSpotFills(params models.FillParams) (*models.V1PageRes[models.ApiFill], error) {
+	path := models.V1SpotFillsPath
+	path += params.GetFillPathParams()
+
+	res, err := NewHttpJsonClient[any, models.V1PageRes[models.ApiFill]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("error in http req spot get fills: %w", err)
+	}
+
+	return res, err
+}
+
+func (client *ApiClient) GetSpotFillsByOrderID(orderID models.OrderID) (*models.GenericResponse[[]models.ApiFill], error) {
+	path := models.V1SpotOrdersPath + "/" + string(orderID) + "/fills"
+
+	res, err := NewHttpJsonClient[any, models.GenericResponse[[]models.ApiFill]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("error in http req spot get fill by order ID: %w", err)
+	}
+
+	if !res.Success {
+		return res, fmt.Errorf("bad request spot fill by order id %s: %v", orderID, res.Error)
+	}
+
+	return res, err
+}
+
+func (client *ApiClient) GetSpotFillsByClientOrderID(orderID models.OrderID) (*models.GenericResponse[[]models.ApiFill], error) {
+	path := models.V1SpotOrdersPath + "/" + models.V1SpotClientOrderIDPrefix + string(orderID) + "/fills"
+
+	res, err := NewHttpJsonClient[any, models.GenericResponse[[]models.ApiFill]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("error in http req spot get fill by client order ID: %w", err)
+	}
+
+	if !res.Success {
+		return res, fmt.Errorf("bad request spot fill by client order id %s: %v", orderID, res.Error)
+	}
+
+	return res, err
 }

--- a/models/fills.go
+++ b/models/fills.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type FillID string
+
+type FillParams struct {
+	StartTime *time.Time
+	EndTime   *time.Time
+	Market    string
+	Limit     int
+	Cursor    string
+}
+
+func (fp *FillParams) IsEmpty() bool {
+	return fp.StartTime == nil && fp.EndTime == nil && fp.Market == "" && fp.Limit == 0 && fp.Cursor == ""
+}
+
+func (fp *FillParams) GetFillPathParams() string {
+	if fp.IsEmpty() {
+		return ""
+	}
+
+	pathParams := "?"
+
+	if fp.StartTime != nil {
+		pathParams += fmt.Sprintf("startTime=%d&", fp.StartTime.UnixMilli())
+	}
+
+	if fp.EndTime != nil {
+		pathParams += fmt.Sprintf("endTime=%d&", fp.EndTime.UnixMilli())
+	}
+
+	if fp.Market != "" {
+		pathParams += fmt.Sprintf("market=%s&", fp.Market)
+	}
+
+	if fp.Limit > 0 {
+		pathParams += fmt.Sprintf("limit=%d&", fp.Limit)
+	}
+
+	if fp.Cursor != "" {
+		pathParams += fmt.Sprintf("cursor=%s&", fp.Cursor)
+	}
+
+	pathParams = strings.TrimSuffix(pathParams, "&")
+
+	return pathParams
+}
+
+type ApiFill struct {
+	FillID        FillID           `json:"id"`
+	OrderID       OrderID          `json:"orderId"`
+	ClientOrderID OrderID          `json:"clientOrderId,omitempty"`
+	Market        Market           `json:"market"`
+	Price         decimal.Decimal  `json:"price"`
+	Size          decimal.Decimal  `json:"size"` // size of fill (base currency)
+	Side          BidAsk           `json:"side"`
+	Cost          decimal.Decimal  `json:"filledCost"` // total cost of fill (quote currency)
+	Fee           decimal.Decimal  `json:"fee"`
+	FeeRebate     *decimal.Decimal `json:"feeRebate,omitempty"`
+	CreatedAt     time.Time        `json:"time"`
+	ADL           *bool            `json:"isADL,omitempty"`
+}

--- a/models/models.go
+++ b/models/models.go
@@ -12,24 +12,22 @@ const (
 	V1MarketsPath = "/v1/markets"
 
 	// Spot trading
-	V1SpotOrdersPath           = "/v1/orders"
-	V1SpotIndividualOrdersPath = "/v1/orders/:orderID"
-	V1SpotOrdersCSVPath        = "/v1/orders/csv"
-
-	V1SpotFillsPath          = "/v1/fills"
-	V1SpotFillsByOrderIDPath = "/v1/orders/:orderID/fills"
-	V1SpotFillsCSVPath       = "/v1/fills/csv"
-
-	V1SpotDepthPath   = "/v1/depth"
-	V1SpotCandlesPath = "/v1/candles"
-
-	// Spot Trading View endpoints
-	V1SpotTradingViewSymbolInfoPath = "/v1/symbol_info"
-	V1SpotTradingViewStreamingPath  = "/v1/streaming"
-	V1SpotTradingViewHistoryPath    = "/v1/history"
+	V1SpotOrdersPath = "/v1/orders"
+	V1SpotFillsPath  = "/v1/fills"
+	V1SpotDepthPath  = "/v1/depth"
 
 	V1SpotClientOrderIDPrefix = "client:"
 )
+
+type V1PageRes[T any] struct {
+	Result   []*T
+	PageInfo APIPageInfo
+}
+
+type APIPageInfo struct {
+	PrevCursor string `json:"prevCursor"`
+	NextCursor string `json:"nextCursor"`
+}
 
 type AccountID string
 


### PR DESCRIPTION
Adds support to the golang client for querying spot market fills.

Output from when running against the sandbox environment:
```
waiting for the service to become available ......
AVAX balance: 9999.999
base-min: 0.001 quote-min: 0.01
best-ask-price: 23.38 best-ask-size: 605.196
order placed, current state: open
order state: canceled
market order placed, current state: fullyFilled
found n-fills for market order: 1
found n-fills by client order ID for market order: 1
found n-fills any orders: 6
```