### PR TITLE
feat: add websocket support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+issues:
+  exclude-rules:
+    - linters:
+      - golint
+      text: "don't use underscores in Go names"
+
+linters:
+  enable:
+    - gofmt
+    - gofumpt
+
+linters-settings:
+  errcheck:
+    exclude-functions:
+      - (net/http.ResponseWriter).Write

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -69,7 +69,6 @@ func (c *ApiClient) computeApiKeyArgs(httpVerb string, path string, request any)
 	sig := generateSignature(c.apiKeyArgs.KeySecret, c.apiKeyArgs.Timestamp, httpVerb, path, body)
 	hexSig := hex.EncodeToString(sig)
 	c.apiKeyArgs.Sign = hexSig
-
 }
 
 // getHeaders returns the headers for a request. It includes the auth headers and any extra headers set on the client.
@@ -159,7 +158,6 @@ func (client *ApiClient) AuthedHello() (*models.GenericResponse[string], error) 
 	jsonClient := NewHttpJsonClient[any, models.GenericResponse[string]](client.ApiEndpoint + path)
 	jsonClient.SetHeaders(client.getHeaders("GET", path, nil))
 	res, err := jsonClient.Get(nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error with http request to authed hello: %s", err)
 	}
@@ -176,7 +174,6 @@ func (client *ApiClient) Markets() (*models.GenericResponse[models.V1GetMarketsR
 	res, err := NewHttpJsonClient[any, models.GenericResponse[models.V1GetMarketsResult]](
 		client.ApiEndpoint + path,
 	).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error with http request to v1 markets: %w", err)
 	}
@@ -194,7 +191,6 @@ func (client *ApiClient) GetBalance(req models.GetBalanceReq) (*models.GenericRe
 	res, err := NewHttpJsonClient[models.GetBalanceReq, models.GenericResponse[models.V0GetBalanceRes]](
 		client.ApiEndpoint + path,
 	).SetHeaders(client.getHeaders("POST", path, req)).Post(req)
-
 	if err != nil {
 		return nil, fmt.Errorf("error with http request to get balance: %w", err)
 	}

--- a/apiclient/http.go
+++ b/apiclient/http.go
@@ -155,8 +155,7 @@ func (rlc *RateLimitedSecureHttpJsonClient[REQUEST_T, REPLY_T]) Get(request REQU
 	return rlc.client.Do("GET", request)
 }
 
-type JsonSerializer[T any] struct {
-}
+type JsonSerializer[T any] struct{}
 
 func (js JsonSerializer[T]) ToJsonString(x T) (string, error) {
 	j, err := json.Marshal(x)

--- a/apiclient/perps_client.go
+++ b/apiclient/perps_client.go
@@ -11,7 +11,6 @@ func (client *ApiClient) AddPerpsOrder(req models.AddOrderReq) (*models.GenericR
 
 	res, err := NewHttpJsonClient[models.AddOrderReq, models.GenericResponse[models.ApiOrder]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("POST", path, req)).Post(req)
-
 	if err != nil {
 		return res, fmt.Errorf("error with http req in spot add order: %w", err)
 	}
@@ -27,7 +26,6 @@ func (client *ApiClient) CancelAllPerpsOrdersOnMarket(market models.Market) erro
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
-
 	if err != nil {
 		return fmt.Errorf("error in http req perps delete all orders: %w", err)
 	}

--- a/apiclient/perps_client.go
+++ b/apiclient/perps_client.go
@@ -1,0 +1,39 @@
+package apiclient
+
+import (
+	"fmt"
+
+	"github.com/Enclave-Markets/enclave-go/models"
+)
+
+func (client *ApiClient) AddPerpsOrder(req models.AddOrderReq) (*models.GenericResponse[models.ApiOrder], error) {
+	path := models.V1PerpsOrdersPath
+
+	res, err := NewHttpJsonClient[models.AddOrderReq, models.GenericResponse[models.ApiOrder]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("POST", path, req)).Post(req)
+
+	if err != nil {
+		return res, fmt.Errorf("error with http req in spot add order: %w", err)
+	}
+	if !res.Success {
+		return res, fmt.Errorf("error in spot add order %v: %v", req, res.Error)
+	}
+
+	return res, err
+}
+
+func (client *ApiClient) CancelAllPerpsOrdersOnMarket(market models.Market) error {
+	path := models.V1PerpsOrdersPath + "?market=" + string(market)
+
+	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
+
+	if err != nil {
+		return fmt.Errorf("error in http req perps delete all orders: %w", err)
+	}
+	if !res.Success {
+		return fmt.Errorf("bad request perps delete all orders: %v", res.Error)
+	}
+
+	return nil
+}

--- a/apiclient/spot_client.go
+++ b/apiclient/spot_client.go
@@ -70,6 +70,22 @@ func (client *ApiClient) CancelAllSpotOrders() error {
 	return nil
 }
 
+func (client *ApiClient) CancelAllSpotOrdersOnMarket(market models.Market) error {
+	path := models.V1SpotOrdersPath + "?market=" + string(market)
+
+	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
+
+	if err != nil {
+		return fmt.Errorf("error in http req spot delete all orders: %w", err)
+	}
+	if !res.Success {
+		return fmt.Errorf("bad request spot delete all orders: %v", res.Error)
+	}
+
+	return nil
+}
+
 func (client *ApiClient) CancelSpotOrder(orderId models.OrderID) (*models.GenericResponse[any], error) {
 	path := models.V1SpotOrdersPath + "/" + string(orderId)
 

--- a/apiclient/spot_client.go
+++ b/apiclient/spot_client.go
@@ -11,7 +11,6 @@ func (client *ApiClient) AddSpotOrder(req models.AddOrderReq) (*models.GenericRe
 
 	res, err := NewHttpJsonClient[models.AddOrderReq, models.GenericResponse[models.ApiOrder]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("POST", path, req)).Post(req)
-
 	if err != nil {
 		return res, fmt.Errorf("error with http req in spot add order: %w", err)
 	}
@@ -27,7 +26,6 @@ func (client *ApiClient) GetSpotDepthBook(market models.Market) (*models.Generic
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[models.BookSnapshot]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error in http req Spot get depth book: %w", err)
 	}
@@ -43,7 +41,6 @@ func (client *ApiClient) GetSpotOrder(orderId models.OrderID) (*models.GenericRe
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[models.ApiOrder]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error in http req spot get order: %w", err)
 	}
@@ -59,7 +56,6 @@ func (client *ApiClient) CancelAllSpotOrders() error {
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
-
 	if err != nil {
 		return fmt.Errorf("error in http req spot delete all orders: %w", err)
 	}
@@ -75,7 +71,6 @@ func (client *ApiClient) CancelAllSpotOrdersOnMarket(market models.Market) error
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
-
 	if err != nil {
 		return fmt.Errorf("error in http req spot delete all orders: %w", err)
 	}
@@ -91,7 +86,6 @@ func (client *ApiClient) CancelSpotOrder(orderId models.OrderID) (*models.Generi
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
-
 	if err != nil {
 		return res, fmt.Errorf("error in http req spot delete order: %w", err)
 	}
@@ -107,7 +101,6 @@ func (client *ApiClient) CancelSpotOrderByClientID(clientOrderId models.OrderID)
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[any]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
-
 	if err != nil {
 		return res, fmt.Errorf("error in http req spot delete order by client id: %w", err)
 	}
@@ -124,7 +117,6 @@ func (client *ApiClient) GetSpotFills(params models.FillParams) (*models.V1PageR
 
 	res, err := NewHttpJsonClient[any, models.V1PageRes[models.ApiFill]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error in http req spot get fills: %w", err)
 	}
@@ -137,7 +129,6 @@ func (client *ApiClient) GetSpotFillsByOrderID(orderID models.OrderID) (*models.
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[[]models.ApiFill]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error in http req spot get fill by order ID: %w", err)
 	}
@@ -154,7 +145,6 @@ func (client *ApiClient) GetSpotFillsByClientOrderID(orderID models.OrderID) (*m
 
 	res, err := NewHttpJsonClient[any, models.GenericResponse[[]models.ApiFill]](
 		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("error in http req spot get fill by client order ID: %w", err)
 	}

--- a/apiclient/types.go
+++ b/apiclient/types.go
@@ -1,0 +1,145 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Enclave-Markets/enclave-go/models"
+)
+
+// Requests
+
+type WebSocketAPIRequest struct {
+	Op            WSRequestType   `json:"op,omitempty"`
+	Channel       ChannelType     `json:"channel,omitempty"`
+	Markets       []models.Market `json:"markets,omitempty"`
+	NumPastTrades *int            `json:"numPastTrades,omitempty"` // This is an internally used parameter for Spot Trades
+	Timeout       *int            `json:"timeout_seconds,omitempty"`
+	Args          *RequestArgs    `json:"args,omitempty"`
+}
+
+type RequestArgs struct {
+	Token          string `json:"token"`
+	KeyId          string `json:"key"`
+	SubaccountId   string `json:"subaccount"`
+	TimeUnixMillis string `json:"time"`
+	Sign           string `json:"sign"`
+}
+
+func (a *RequestArgs) IsJWTLogin() bool {
+	return a.Token != ""
+}
+
+type WSRequestType string
+
+const (
+	Ping        WSRequestType = "ping"
+	Subscribe   WSRequestType = "subscribe"
+	Unsubscribe WSRequestType = "unsubscribe"
+	Login       WSRequestType = "login"
+)
+
+type ChannelType string
+
+func TopOfBooksPerps() ChannelType {
+	return ChannelType("topOfBooksPerps")
+}
+func FillsPerps() ChannelType {
+	return ChannelType("fillsPerps")
+}
+func PerpsPositions() ChannelType {
+	return "positionsPerps"
+}
+func PerpsMarkPrices() ChannelType {
+	return "markPricesPerps"
+}
+func TopOfBooksSpot() ChannelType {
+	return ChannelType("topOfBooksSpot")
+}
+func FillsSpot() ChannelType {
+	return ChannelType("fillsSpot")
+}
+
+// Responses
+
+type WebSocketAPIResponse struct {
+	Type    WSResponseType `json:"type"`
+	Channel ChannelType    `json:"channel,omitempty"`
+	Code    int            `json:"code,omitempty"`
+	Msg     string         `json:"msg,omitempty"`
+	Data    any            `json:"data,omitempty"`
+}
+
+func UnmarshalWebSocketAPIResponse(data []byte) (*WebSocketAPIResponse, error) {
+	type Temp struct {
+		Type    WSResponseType  `json:"type"`
+		Channel ChannelType     `json:"channel,omitempty"`
+		Code    int             `json:"code,omitempty"`
+		Msg     string          `json:"msg,omitempty"`
+		Data    json.RawMessage `json:"data,omitempty"`
+	}
+
+	var result *WebSocketAPIResponse
+
+	var parsed Temp
+	err := json.Unmarshal(data, &parsed)
+	if err != nil {
+		return result, err
+	}
+	result = &WebSocketAPIResponse{
+		Type:    parsed.Type,
+		Channel: parsed.Channel,
+		Code:    parsed.Code,
+		Msg:     parsed.Msg,
+	}
+	switch parsed.Type {
+	case Pong:
+		result.Data = nil
+	case Error:
+		result.Data = nil
+	case Subscribed:
+		var req WebSocketAPIRequest
+		err = json.Unmarshal(parsed.Data, &req)
+		result.Data = req
+	case Unsubscribed:
+		var req WebSocketAPIRequest
+		err = json.Unmarshal(parsed.Data, &req)
+		result.Data = req
+	case Update:
+		switch parsed.Channel {
+		case TopOfBooksPerps(), TopOfBooksSpot():
+			var temp []*models.ApiBookSnapshot
+			err = json.Unmarshal(parsed.Data, &temp)
+			result.Data = temp
+		case FillsPerps(), FillsSpot():
+			var temp []*models.ApiFill
+			err = json.Unmarshal(parsed.Data, &temp)
+			result.Data = temp
+		case PerpsPositions():
+			var temp []*models.ApiPosition
+			err = json.Unmarshal(parsed.Data, &temp)
+			result.Data = temp
+		case PerpsMarkPrices():
+			var temp []*models.GetMarkPriceRes
+			err = json.Unmarshal(parsed.Data, &temp)
+			result.Data = temp
+		default:
+			return nil, fmt.Errorf("couldn't unmarshal response: unknown channel %s", parsed.Channel)
+		}
+	case LoggedIn:
+		result.Data = nil
+	}
+
+	return result, err
+}
+
+type WSResponseType string
+
+const (
+	Pong         WSResponseType = "pong"
+	Error        WSResponseType = "error"
+	Subscribed   WSResponseType = "subscribed"
+	Unsubscribed WSResponseType = "unsubscribed"
+	Update       WSResponseType = "update"
+	LoggedIn     WSResponseType = "loggedIn"
+)

--- a/apiclient/types.go
+++ b/apiclient/types.go
@@ -44,18 +44,23 @@ type ChannelType string
 func TopOfBooksPerps() ChannelType {
 	return ChannelType("topOfBooksPerps")
 }
+
 func FillsPerps() ChannelType {
 	return ChannelType("fillsPerps")
 }
+
 func PerpsPositions() ChannelType {
 	return "positionsPerps"
 }
+
 func PerpsMarkPrices() ChannelType {
 	return "markPricesPerps"
 }
+
 func TopOfBooksSpot() ChannelType {
 	return ChannelType("topOfBooksSpot")
 }
+
 func FillsSpot() ChannelType {
 	return ChannelType("fillsSpot")
 }

--- a/apiclient/websocket_client.go
+++ b/apiclient/websocket_client.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/url"
 	"strings"
-
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -86,7 +85,6 @@ func (client *ApiClient) NewWebsocketConnection() (*WebsocketConn, error) {
 }
 
 func (c *ApiClient) GetWebsocketLoginArgs() *RequestArgs {
-
 	if c.apiKeyArgs != nil {
 		c.computeApiKeyArgs("enclave_ws_login", "", nil)
 		return &RequestArgs{

--- a/apiclient/websocket_client.go
+++ b/apiclient/websocket_client.go
@@ -1,0 +1,197 @@
+package apiclient
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type WebsocketConn struct {
+	wsConn        *websocket.Conn
+	readDeadline  time.Duration
+	writeDeadline time.Duration
+}
+
+const DefaultTimeout = 5 * time.Second
+
+func GetTlsConfig(apiEndpoint string) *tls.Config {
+	insecureSkipVerify := false
+	u, err := url.Parse(apiEndpoint)
+	if err == nil {
+
+		host, _, _ := net.SplitHostPort(u.Host)
+		switch host {
+		case "localhost", "127.0.0.1", "0.0.0.0", "engine", "monolith":
+			insecureSkipVerify = true
+		default:
+			// single name is probably from Docker
+			parts := strings.Split(host, ".")
+			if len(parts) == 1 {
+				insecureSkipVerify = true
+			}
+		}
+	}
+
+	return &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+	}
+}
+
+func (client *ApiClient) NewWebsocketConnection() (*WebsocketConn, error) {
+	u, err := url.Parse(client.ApiEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the api endpoint %s: %s", client.ApiEndpoint, err.Error())
+	}
+	host, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		if u.Host != "" {
+			host = u.Host
+		} else {
+			return nil, err
+		}
+	}
+	spotWsEndpoint := fmt.Sprintf("wss://%s/ws", host)
+
+	dialer := *websocket.DefaultDialer
+	dialer.TLSClientConfig = GetTlsConfig(spotWsEndpoint)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	conn, _, err := dialer.DialContext(ctx, spotWsEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	wsConn := &WebsocketConn{
+		wsConn:        conn,
+		readDeadline:  DefaultTimeout,
+		writeDeadline: DefaultTimeout,
+	}
+
+	err = wsConn.websocketLogin(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return wsConn, nil
+}
+
+func (c *ApiClient) GetWebsocketLoginArgs() *RequestArgs {
+
+	if c.apiKeyArgs != nil {
+		c.computeApiKeyArgs("enclave_ws_login", "", nil)
+		return &RequestArgs{
+			KeyId:          c.apiKeyArgs.KeyId,
+			TimeUnixMillis: c.apiKeyArgs.Timestamp,
+			Sign:           c.apiKeyArgs.Sign,
+		}
+	} else {
+		return nil
+	}
+}
+
+func (c *WebsocketConn) SetReadDeadline(t time.Duration) {
+	c.readDeadline = t
+}
+
+func (c *WebsocketConn) SetWriteDeadline(t time.Duration) {
+	c.writeDeadline = t
+}
+
+func (c *WebsocketConn) SendMessage(req WebSocketAPIRequest) error {
+	var err error
+	if c.writeDeadline == 0 {
+		err = c.wsConn.SetWriteDeadline(time.Time{})
+	} else {
+		err = c.wsConn.SetWriteDeadline(time.Now().Add(c.writeDeadline))
+	}
+	if err != nil {
+		return err
+	}
+	err = c.wsConn.WriteJSON(req)
+	_ = c.wsConn.SetWriteDeadline(time.Time{})
+	return err
+}
+
+func (c *WebsocketConn) ReadMessage() (*WebSocketAPIResponse, error) {
+	var err error
+	if c.readDeadline == 0 {
+		err = c.wsConn.SetReadDeadline(time.Time{})
+	} else {
+		err = c.wsConn.SetReadDeadline(time.Now().Add(c.readDeadline))
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	_, p, err := c.wsConn.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.wsConn.SetReadDeadline(time.Time{})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := UnmarshalWebSocketAPIResponse(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (c *WebsocketConn) Close() error {
+	return c.wsConn.Close()
+}
+
+func IsCloseError(err error) bool {
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+		return true
+	}
+	netErr, ok := err.(*net.OpError)
+	if ok && netErr.Unwrap() == net.ErrClosed {
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	return false
+}
+
+func (conn *WebsocketConn) websocketLogin(client *ApiClient) error {
+	// Skip login if no credentials are provided
+	args := client.GetWebsocketLoginArgs()
+	if args == nil {
+		return nil
+	}
+	req := WebSocketAPIRequest{Op: Login, Args: args}
+	err := conn.SendMessage(req)
+	if err != nil {
+		conn.wsConn.Close()
+		return fmt.Errorf("failed to write login message to websocket: %s", err.Error())
+	}
+
+	res, err := conn.ReadMessage()
+	if err != nil {
+		conn.wsConn.Close()
+		return fmt.Errorf("failed to read message from websocket: %s", err.Error())
+	}
+
+	if res.Type != LoggedIn {
+		conn.wsConn.Close()
+		return fmt.Errorf("unexpected response to login message: %s %s", res.Type, res.Msg)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/Enclave-Markets/enclave-go
 
-go 1.22
-
-toolchain go1.22.9
+go 1.21
 
 require (
+	github.com/gorilla/websocket v1.5.3
 	github.com/shopspring/decimal v1.4.0
 	golang.org/x/time v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 )
 
 func main() {
-
 	// the trading pair that will be used, and balance symbol to check
 	symbol := models.Symbol("AVAX")
 	market := models.Market("AVAX-USDC")
@@ -168,5 +167,4 @@ func main() {
 		fmt.Println("could not find any fills!")
 	}
 	fmt.Println("found n-fills any orders:", len(allFillsResp.Result))
-
 }

--- a/models/markets.go
+++ b/models/markets.go
@@ -8,8 +8,10 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-type Market string
-type Symbol string
+type (
+	Market string
+	Symbol string
+)
 
 type V1GetMarketsResult struct {
 	// Spot markets that the user is allowed to trade in

--- a/models/models.go
+++ b/models/models.go
@@ -1,5 +1,11 @@
 package models
 
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
 const (
 
 	// Tool
@@ -17,6 +23,12 @@ const (
 	V1SpotDepthPath  = "/v1/depth"
 
 	V1SpotClientOrderIDPrefix = "client:"
+
+	// Perps trading
+	V1PerpsOrdersPath = "/v1/perps/orders"
+
+	// Cross
+	V0PricePath = "/v0/price"
 )
 
 type V1PageRes[T any] struct {
@@ -73,4 +85,50 @@ type GetBalanceReq struct {
 	// example:AVAX
 	// required:true
 	Symbol Symbol `json:"symbol"`
+}
+
+type GetMarkPriceRes struct {
+	// trading market pair
+	// example:AVAX-USD.PERP
+	// required:true
+	Market    Market          `json:"market"`
+	MarkPrice decimal.Decimal `json:"markPrice"`
+}
+
+type ApiPosition struct {
+	Market                 Market           `json:"market"`
+	Direction              string           `json:"direction"`
+	NetQuantity            decimal.Decimal  `json:"netQuantity"`
+	AverageEntryPrice      decimal.Decimal  `json:"averageEntryPrice"`
+	UsedMargin             decimal.Decimal  `json:"usedMargin"`
+	UnrealizedPnl          decimal.Decimal  `json:"unrealizedPnl"`
+	MarkPrice              decimal.Decimal  `json:"markPrice"`
+	LiquidationPrice       decimal.Decimal  `json:"liquidationPrice"`
+	BankruptcyPrice        decimal.Decimal  `json:"bankruptcyPrice"`
+	MaintenanceMargin      decimal.Decimal  `json:"maintenanceMargin"`
+	NotionalValue          decimal.Decimal  `json:"notionalValue"`
+	Leverage               decimal.Decimal  `json:"leverage"`
+	NetFundingSinceNeutral decimal.Decimal  `json:"netFundingSinceNeutral"`
+	StopLossTriggerPrice   *decimal.Decimal `json:"stopLossTriggerPrice,omitempty"`
+	TakeProfitTriggerPrice *decimal.Decimal `json:"takeProfitTriggerPrice,omitempty"`
+}
+
+type ApiBookSnapshots []*ApiBookSnapshot
+
+type ApiBookSnapshot struct {
+	Market Market      `json:"market"`
+	Time   time.Time   `json:"time"`
+	Asks   []BookLevel `json:"asks"`
+	Bids   []BookLevel `json:"bids"`
+}
+
+type GetPriceReq struct {
+	Pair CurrencyPair `json:"pair"`
+}
+
+type V0GetPriceRes struct {
+	Pair      CurrencyPair    `json:"pair"`
+	Available bool            `json:"available"`
+	Price     decimal.Decimal `json:"price"`
+	QuotedAt  string          `json:"quotedAt"`
 }

--- a/models/orders.go
+++ b/models/orders.go
@@ -27,8 +27,10 @@ type AddOrderReq struct {
 
 type BidAsk bool
 
-const Bid BidAsk = true
-const Ask BidAsk = false
+const (
+	Bid BidAsk = true
+	Ask BidAsk = false
+)
 
 func (b BidAsk) Opposite() BidAsk {
 	return !b
@@ -64,8 +66,10 @@ func (b BidAsk) MarshalJSON() ([]byte, error) {
 
 type OrderType bool
 
-const OrderTypeLimit OrderType = false
-const OrderTypeMarket OrderType = true
+const (
+	OrderTypeLimit  OrderType = false
+	OrderTypeMarket OrderType = true
+)
 
 func (o OrderType) String() string {
 	if o {
@@ -97,8 +101,10 @@ func (o *OrderType) UnmarshalJSON(data []byte) error {
 
 type OrderTimeInForce string
 
-const OrderTimeInForceGoodUntilCancelled OrderTimeInForce = "GTC"
-const OrderTimeInForceImmediateOrCancel OrderTimeInForce = "IOC"
+const (
+	OrderTimeInForceGoodUntilCancelled OrderTimeInForce = "GTC"
+	OrderTimeInForceImmediateOrCancel  OrderTimeInForce = "IOC"
+)
 
 type ApiOrder struct {
 	OrderID        OrderID          `json:"orderId"`


### PR DESCRIPTION
Basic support has been added for websocket connections to the Enclave exchange.

Also note that the version in `go.mod` has been dropped to `1.21` so that it is consistent with all other tools.