### PR TITLE
chore: add method to gracefully signal to close a websocket connection

### DIFF
--- a/apiclient/websocket_client.go
+++ b/apiclient/websocket_client.go
@@ -149,6 +149,10 @@ func (c *WebsocketConn) ReadMessage() (*WebSocketAPIResponse, error) {
 	return res, nil
 }
 
+func (c *WebsocketConn) WriteCloseMessage() error {
+	return c.wsConn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+}
+
 func (c *WebsocketConn) Close() error {
 	return c.wsConn.Close()
 }


### PR DESCRIPTION
Allow users of the API client to gracefully close their websocket connection.