### PR TITLE
feat: add pnl to fills type

### DIFF
--- a/models/fills.go
+++ b/models/fills.go
@@ -67,4 +67,5 @@ type ApiFill struct {
 	FeeRebate     *decimal.Decimal `json:"feeRebate,omitempty"`
 	CreatedAt     time.Time        `json:"time"`
 	ADL           *bool            `json:"isADL,omitempty"`
+	RealizedPNL   *decimal.Decimal `json:"pnl,omitempty"`
 }


### PR DESCRIPTION
PnL has been recently added to the fill's API, lets also add it to the `enclave-go` client.