### PR TITLE
feat: implement retrieval of perpetual futures contracts

### DIFF
--- a/apiclient/perps_client.go
+++ b/apiclient/perps_client.go
@@ -50,3 +50,20 @@ func (client *ApiClient) CancelAllPerpsOrdersOnMarket(market models.Market) erro
 
 	return nil
 }
+
+// GetPerpsContracts retrieves all perpetual futures contracts from the /v1/perps/contracts endpoint
+func (client *ApiClient) GetPerpsContracts() (*models.GenericResponse[[]models.PerpsContract], error) {
+	path := models.V1PerpsContractsPath
+
+	res, err := NewHttpJsonClient[any, models.GenericResponse[[]models.PerpsContract]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("GET", path, nil)).Get(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute perps contracts request: %w", err)
+	}
+
+	if !res.Success {
+		return res, fmt.Errorf("failed to get perps contracts: %v", res.Error)
+	}
+
+	return res, nil
+}

--- a/main.go
+++ b/main.go
@@ -167,4 +167,65 @@ func main() {
 		fmt.Println("could not find any fills!")
 	}
 	fmt.Println("found n-fills any orders:", len(allFillsResp.Result))
+
+	targetMarket := models.Market("AVAX-USD.P")
+	perpsResp, err := client.GetPerpsContracts()
+	if err != nil {
+		fmt.Printf("Failed to get perps contracts: %v\n", err)
+	} else {
+		contracts := perpsResp.Result
+		fmt.Printf("Found %d perps contracts\n", len(contracts))
+
+		// Display summary of all contracts
+		fmt.Println("\nSummary of all contracts:")
+		fmt.Println("----------------------------------------------------")
+		fmt.Printf("%-12s | %-8s | %-8s | %-8s\n", "MARKET", "STATUS", "DISABLED", "LAST PRICE")
+		fmt.Println("----------------------------------------------------")
+		for _, contract := range contracts {
+			status := "OPEN"
+			if contract.IsClosed {
+				status = "CLOSED"
+			}
+			fmt.Printf("%-12s | %-8s | %-8t | %-8s\n",
+				contract.Market,
+				status,
+				contract.Disabled,
+				contract.LastPrice)
+		}
+
+		// Check specific market
+		fmt.Printf("\nLooking for target market: %s\n", targetMarket)
+		var found bool
+		for _, contract := range contracts {
+			if contract.Market == targetMarket {
+				found = true
+				status := "OPEN"
+				if contract.IsClosed {
+					status = "CLOSED"
+				}
+
+				// Print detailed information about the target market
+				fmt.Println("\nDetailed Information:")
+				fmt.Println("----------------------------------------------------")
+				fmt.Printf("Market:               %s\n", contract.Market)
+				fmt.Printf("Status:               %s\n", status)
+				fmt.Printf("Base/Quote:           %s/%s\n", contract.BaseCurrency, contract.QuoteCurrency)
+				fmt.Printf("Contract Type:        %s\n", contract.ContractType)
+				fmt.Printf("Last Price:           %s\n", contract.LastPrice)
+				fmt.Printf("Bid/Ask:              %s/%s\n", contract.Bid, contract.Ask)
+				fmt.Printf("24h High/Low:         %s/%s\n", contract.High, contract.Low)
+				fmt.Printf("24h Change:           %s%%\n", contract.PriceChangePercent)
+				fmt.Printf("Open Interest:        %s (%s USD)\n", contract.OpenInterest, contract.OpenInterestUsd)
+				fmt.Printf("Funding Rate:         %s\n", contract.FundingRate)
+				fmt.Printf("Next Funding:         %s\n", contract.NextFundingRateTimestamp)
+				fmt.Printf("Maker/Taker Fee:      %s/%s\n", contract.MakerFee, contract.TakerFee)
+				fmt.Printf("Tags:                 %v\n", contract.Tags)
+				break
+			}
+		}
+
+		if !found {
+			fmt.Printf("\nTarget market %s not found in contracts\n", targetMarket)
+		}
+	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -28,6 +28,7 @@ const (
 	// Perps trading
 	V1PerpsOrdersPath      = "/v1/perps/orders"
 	V1PerpsBatchOrdersPath = "/v1/perps/orders/batch"
+	V1PerpsContractsPath   = "/v1/perps/contracts"
 
 	// Cross
 	V0PricePath = "/v0/price"
@@ -133,4 +134,34 @@ type V0GetPriceRes struct {
 	Available bool            `json:"available"`
 	Price     decimal.Decimal `json:"price"`
 	QuotedAt  string          `json:"quotedAt"`
+}
+
+// PerpsContract represents a perpetual futures contract
+type PerpsContract struct {
+	Market                   Market   `json:"market"`
+	ProductType              string   `json:"productType"`
+	ContractType             string   `json:"contractType"`
+	BaseCurrency             string   `json:"baseCurrency"`
+	QuoteCurrency            string   `json:"quoteCurrency"`
+	Disabled                 bool     `json:"disabled"`
+	LastPrice                string   `json:"lastPrice"`
+	BaseVolume               string   `json:"baseVolume"`
+	QuoteVolume              string   `json:"quoteVolume"`
+	UsdVolume                string   `json:"usdVolume"`
+	Bid                      string   `json:"bid"`
+	Ask                      string   `json:"ask"`
+	High                     string   `json:"high"`
+	Low                      string   `json:"low"`
+	OpenInterest             string   `json:"openInterest"`
+	OpenInterestUsd          string   `json:"openInterestUsd"`
+	IndexPrice               string   `json:"indexPrice"`
+	IndexCurrency            string   `json:"indexCurrency"`
+	FundingRate              string   `json:"fundingRate"`
+	NextFundingRate          string   `json:"nextFundingRate"`
+	NextFundingRateTimestamp string   `json:"nextFundingRateTimestamp"`
+	MakerFee                 string   `json:"makerFee"`
+	TakerFee                 string   `json:"takerFee"`
+	PriceChangePercent       string   `json:"priceChangePercent"`
+	IsClosed                 bool     `json:"isClosed"`
+	Tags                     []string `json:"tags"`
 }


### PR DESCRIPTION
- Added GetPerpsContracts method to ApiClient for fetching contracts from the API.
- Introduced PerpsContract model to represent contract details.
- Updated main.go to display a summary of all contracts and detailed information for a specific target market.