### PR TITLE
fix: make client more thread safe

### DIFF
--- a/apiclient/websocket_client.go
+++ b/apiclient/websocket_client.go
@@ -86,11 +86,11 @@ func (client *ApiClient) NewWebsocketConnection() (*WebsocketConn, error) {
 
 func (c *ApiClient) GetWebsocketLoginArgs() *RequestArgs {
 	if c.apiKeyArgs != nil {
-		c.computeApiKeyArgs("enclave_ws_login", "", nil)
+		timestamp, sig := c.computeApiKeyArgs("enclave_ws_login", "", nil)
 		return &RequestArgs{
 			KeyId:          c.apiKeyArgs.KeyId,
-			TimeUnixMillis: c.apiKeyArgs.Timestamp,
-			Sign:           c.apiKeyArgs.Sign,
+			TimeUnixMillis: timestamp,
+			Sign:           sig,
 		}
 	} else {
 		return nil


### PR DESCRIPTION
The go client is currently not thread safe because we store the signature generated using the API key in the client itself, and then read from it to put it into the headers for the HTTP request.

This means that if you have to concurrent calls into the client, we could be calculating signatures at the same time and it when we actually send with the request will not match the signature.