### PR TITLE
feat: add api for batch cancel by client-id

### DIFF
--- a/apiclient/perps_client.go
+++ b/apiclient/perps_client.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Enclave-Markets/enclave-go/models"
 )
@@ -34,6 +35,26 @@ func (client *ApiClient) AddPerpsBatchOrders(req models.BatchAddOrderReq) (*mode
 	}
 
 	return res, err
+}
+
+func (client *ApiClient) CancelPerpsOrdersByClientId(clientIds []models.ClientOrderID) (*models.GenericResponse[models.BatchCancelRes], error) {
+
+	ids := make([]string, 0, len(clientIds))
+	for _, id := range clientIds {
+		ids = append(ids, "client:"+string(id))
+	}
+
+	path := models.V1PerpsBatchOrdersPath + "?orderIDs=" + strings.Join(ids, ",")
+	res, err := NewHttpJsonClient[any, models.GenericResponse[models.BatchCancelRes]](
+		client.ApiEndpoint + path).SetHeaders(client.getHeaders("DELETE", path, nil)).Delete(nil)
+	if err != nil {
+		return res, fmt.Errorf("error in http req perps delete batch: %w", err)
+	}
+	if !res.Success {
+		return res, fmt.Errorf("bad request perps delete batch: %v", res.Error)
+	}
+
+	return res, nil
 }
 
 func (client *ApiClient) CancelAllPerpsOrdersOnMarket(market models.Market) error {

--- a/models/orders.go
+++ b/models/orders.go
@@ -9,6 +9,7 @@ import (
 )
 
 type OrderID string
+type ClientOrderID string
 
 type BatchAddOrderReq struct {
 	Orders []*AddOrderReq `json:"orders"`
@@ -21,6 +22,24 @@ type BatchAddOrderRes struct {
 	FailedOrders []*ErroredAddOrderReq `json:"failedOrders"`
 }
 
+type BatchCancelRes struct {
+	// Successfully cancelled orders
+	SuccessfulCancels []*ApiOrder `json:"successfulCancels"`
+
+	// FailedCancels cancel attempts
+	FailedCancels []*CancelError `json:"failedCancels"`
+}
+
+type CancelError struct {
+	// Order ID that failed to cancel
+	OrderID string `json:"orderId"`
+
+	// Error message explaining why cancel failed
+	Error string `json:"error"`
+
+	// Empty if the error isn't a semantic error
+	ErrorCode string `json:"errorCode"`
+}
 type ErroredAddOrderReq struct {
 	Order        *AddOrderReq `json:"order"`
 	ErrorMessage string       `json:"error"`


### PR DESCRIPTION
We need the GoBot to be able to cancel specific orders, so we will add this functionality to the API client.